### PR TITLE
Add authorization header to requests

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,9 +26,9 @@ type deploymentAPI struct {
 
 func (api *deploymentAPI) installerHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	apiToken := getApitoken(r)
+	apiToken := r.URL.Query().Get("Api-Token")
 	if apiToken == "" {
-		apiToken = r.URL.Query().Get("Api-Token")
+		apiToken = strings.Split(r.Header.Get("Authorization"), " ")[1]
 	}
 	key := queryKey{
 		apiToken,
@@ -54,7 +54,7 @@ func (api *deploymentAPI) registerHandler(w http.ResponseWriter, r *http.Request
 	installerType := r.FormValue("installerType")
 	apiToken := r.FormValue("apiToken")
 	if apiToken == "" {
-		apiToken = getApitoken(r)
+		apiToken = strings.Split(r.Header.Get("Authorization"), " ")[1]
 	}
 	if platform == "" || installerType == "" || apiToken == "" {
 		w.WriteHeader(http.StatusBadRequest)
@@ -143,12 +143,6 @@ func makeResponseWriter(platform, installerType string, settings url.Values) (fu
 	default:
 		return nil, fmt.Errorf("Unknown platform: %s", platform)
 	}
-}
-
-func getApitoken(r *http.Request) string {
-	headerSplit := strings.Split(r.Header.Get("Authorization"), " ")
-	apiToken := headerSplit[len(headerSplit)-1]
-	return apiToken
 }
 
 func main() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,12 +25,12 @@ type deploymentAPI struct {
 
 func (api *deploymentAPI) installerHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
+	authHeader := r.Header.Get("Authorization")
 	key := queryKey{
-		r.URL.Query().Get("Api-Token"),
+		authHeader,
 		vars["platform"],
 		vars["installerType"],
 	}
-
 	api.mtx.Lock()
 	handler, ok := api.Mocks[key]
 	api.mtx.Unlock()
@@ -48,8 +48,7 @@ func (api *deploymentAPI) installerHandler(w http.ResponseWriter, r *http.Reques
 func (api *deploymentAPI) registerHandler(w http.ResponseWriter, r *http.Request) {
 	platform := r.FormValue("platform")
 	installerType := r.FormValue("installerType")
-	apiToken := r.FormValue("apiToken")
-
+	apiToken := r.Header.Get("Authorization")
 	if platform == "" || installerType == "" || apiToken == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("One of required arguments are missing: platform, installerType, apiToken\n"))

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,7 +48,10 @@ func (api *deploymentAPI) installerHandler(w http.ResponseWriter, r *http.Reques
 func (api *deploymentAPI) registerHandler(w http.ResponseWriter, r *http.Request) {
 	platform := r.FormValue("platform")
 	installerType := r.FormValue("installerType")
-	apiToken := r.Header.Get("Authorization")
+	apiToken := r.FormValue("apiToken")
+	if apiToken == "" {
+		apiToken = r.Header.Get("Authorization")
+	}
 	if platform == "" || installerType == "" || apiToken == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("One of required arguments are missing: platform, installerType, apiToken\n"))


### PR DESCRIPTION
POST registration request example:
`$ curl -d "platform=unix&installerType=default" -H "Authorization: Api-token xyz" -H "Content-Type: application/x-www-form-urlencoded" -X POST http://127.0.0.1:8080/register`

GET request example:
`$ curl  -H "Authorization: Api-token xyz" "http://127.0.0.1:8080/v1/deployment/installer/agent/unix/default/latest"`
